### PR TITLE
Add: Pitch playing using abstracted interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,6 @@ add_executable(chip_8_emulator main.cpp
 )
 
 find_package(SDL2 REQUIRED)
-find_package(SDL2_image REQUIRED)
-find_package(SDL2_mixer REQUIRED)
 
 target_compile_features(chip_8_emulator
         PRIVATE

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -78,6 +78,8 @@ namespace Chip8 {
             return;
         }
 
+        this->audio_spec = spec;
+
         SDL_PauseAudio(0);
     }
 
@@ -141,6 +143,16 @@ namespace Chip8 {
         uint8_t key = this->key_mapping->at(keysym.sym);    // TODO: Add validation
         return key_states->erase(key);
     }
+
+    SDL_AudioCallback Platform::audio_callback(void *userdata, Uint8 *stream, int len) {
+        Sint16*   buf   = reinterpret_cast<Sint16*>(stream);
+        int       samples = len / sizeof(Sint16);  // number of 16-bit samples
+
+        for (int i = 0; i < samples; i++) {
+
+        }
+    }
+
 
     bool Platform::check_valid() {
         if (!chip8_->get_rom_loaded()) return false;

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -61,11 +61,18 @@ private:
     std::chrono::microseconds cycle_period;
     std::chrono::microseconds last_cycle_time;
 
+    SDL_AudioSpec audio_spec;
+
     struct AudioState {
         double phase;           // current angle in radians
         double phase_increment; // 2π·frequency/sample_rate
+        double frequency;
         bool tone_on;           // whether to emit tone or silence
+        int sample_rate;
+        int amplitude;
     };
+
+    AudioState curr_audio_state;
 };
 
 } // Chip8

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -37,7 +37,7 @@ public:
 
     const uint16_t SAMPLE_RATE = 44100;
     const uint16_t BUFFER_SIZE = 4096;
-    void init_sdl_mixer();
+    int init_sdl_audio();
 
     int add_subsystem(uint32_t subsystem_code);
 
@@ -46,8 +46,9 @@ public:
     int add_key_state(SDL_Keysym keysym);
     int remove_key_state(SDL_Keysym keysym);
 
-    SDL_AudioCallback audio_callback(void *userdata, Uint8 *stream, int len);
+    static void audio_callback(void *userdata, Uint8 *stream, int len);
     void play_sound();
+    void disable_sound();
 
     int create_window_layer(); // TODO
 
@@ -61,18 +62,19 @@ private:
     std::chrono::microseconds cycle_period;
     std::chrono::microseconds last_cycle_time;
 
-    SDL_AudioSpec audio_spec;
+    std::unique_ptr<SDL_AudioSpec> want_audio_spec;
+    std::unique_ptr<SDL_AudioSpec> have_audio_spec;
 
-    struct AudioState {
-        double phase;           // current angle in radians
+    struct AudioData {
+        double phase;           // current phase (in 2π) of the oscillator
         double phase_increment; // 2π·frequency/sample_rate
-        double frequency;
+        double frequency;       // Desired pitch in Hz
         bool tone_on;           // whether to emit tone or silence
-        int sample_rate;
-        int amplitude;
+        int sample_rate;        // default: 48000
+        int amplitude;          // max amplitude for 16-bits
     };
 
-    AudioState curr_audio_state;
+    std::unique_ptr<AudioData> curr_audio_data;
 };
 
 } // Chip8

--- a/src/hardware/chip.cpp
+++ b/src/hardware/chip.cpp
@@ -109,6 +109,12 @@ namespace Chip8 {
         return 0;
     }
 
+    void Chip::set_sound_timer(uint8_t time) {
+        sound_timer = time;
+        // TODO Add logic that turns sound on
+    }
+
+
 
     int Chip::cycle() {
         // validation

--- a/src/hardware/chip.h
+++ b/src/hardware/chip.h
@@ -46,6 +46,8 @@ namespace Chip8 {
         bool get_rom_loaded();
         int load_rom(std::ifstream *file_stream);
 
+        void set_sound_timer(uint8_t time);
+
         int decrement_timers();
 
         int cycle();    // main loop


### PR DESCRIPTION
Added sound playing using default device using oscillation generators and SDL streams. You can specify which pitch to play using `Platform::curr_audio_data->frequency` (in Hz). The current default is set to `440.0` which is **A4**.